### PR TITLE
Generate javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <assertj.version>3.22.0</assertj.version>
     <maven-surefire-plugin.version>3.0.0-M6</maven-surefire-plugin.version>
+    <maven.javadoc.plugin.version>3.4.1</maven.javadoc.plugin.version>
   </properties>
 
   <dependencies>
@@ -197,4 +198,26 @@
       </plugin>
     </plugins>
   </build>
+  <reporting>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-javadoc-plugin</artifactId>
+              <version>${maven.javadoc.plugin.version}</version>
+              <configuration>
+                  <source>11</source>
+              </configuration>
+          </plugin>
+          <plugin>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs-maven-plugin</artifactId>
+              <version>4.5.3.0</version>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-project-info-reports-plugin</artifactId>
+              <version>3.0.0</version>
+          </plugin>
+      </plugins>
+  </reporting>
 </project>

--- a/src/main/java/com/foursquare/presto/h3/CellToParentFunction.java
+++ b/src/main/java/com/foursquare/presto/h3/CellToParentFunction.java
@@ -6,6 +6,7 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 
+/** Function wrapping {@link com.uber.h3core.H3Core#cellToParent(long, int)} */
 public final class CellToParentFunction {
   @ScalarFunction(value = "h3_cell_to_parent")
   @Description("Truncate H3 index to parent")

--- a/src/main/java/com/foursquare/presto/h3/LatLngToCellFunction.java
+++ b/src/main/java/com/foursquare/presto/h3/LatLngToCellFunction.java
@@ -6,6 +6,7 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 
+/** Function wrapping {@link com.uber.h3core.H3Core#latLngToCell(double, double, int)} */
 public final class LatLngToCellFunction {
   @ScalarFunction(value = "h3_latlng_to_cell")
   @Description("Convert degrees lat/lng to H3 index")


### PR DESCRIPTION
gh-pages is generated from the javadocs output, but the javadocs were not generated by Maven without the reporting plugin.