### PR TITLE
Add JTS core as a dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <presto.version>0.277</presto.version>
+    <presto.version>0.286</presto.version>
     <junit-jupiter.version>5.8.2</junit-jupiter.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
@@ -86,6 +86,12 @@
       <groupId>com.uber</groupId>
       <artifactId>h3</artifactId>
       <version>4.0.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>1.17.0</version>
     </dependency>
 
     <dependency>
@@ -182,6 +188,15 @@
         <version>${maven-shade-plugin.version}</version>
         <configuration>
           <createDependencyReducedPom>false</createDependencyReducedPom>
+          <relocations>
+            <relocation>
+              <pattern>org.locationtech.jts</pattern>
+              <shadedPattern>com.foursquare.h3.shaded_relocated.org.locationtech.jts</shadedPattern>
+              <includes>
+                <include>org.locationtech.jts.**</include>
+              </includes>
+            </relocation>
+          </relocations>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Previously, this was added as a transitive dependency, which made it susceptible to breaking whenver Presto would upgrade its JTS library.  It's now included and shaded to make it resilient to Presto upgrades.